### PR TITLE
Add custom image and cluster role binding

### DIFF
--- a/charts/vscode-server/Chart.yaml
+++ b/charts/vscode-server/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.4.0"
+appVersion: "v0.1.0"
 
 home: https://github.com/estenrye/helm-charts
 

--- a/charts/vscode-server/README.md
+++ b/charts/vscode-server/README.md
@@ -1,6 +1,6 @@
 # vscode-server For Kubernetes
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square) ![Docker](https://img.shields.io/badge/docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square) ![Docker](https://img.shields.io/badge/docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
 ![Helm](https://img.shields.io/badge/helm-0F1689?style=for-the-badge&logo=helm&logoColor=white)
 
 ## Description
@@ -21,7 +21,7 @@ helm repo update
 To install the chart with the release name vscode-server run:
 
 ```bash
-helm install vscode-server estenrye-helm-charts/vscode-server 0.5.2
+helm install vscode-server estenrye-helm-charts/vscode-server 0.5.3
 ```
 
 After a few seconds, Bitwarden Directory Connector should be running as a CronJob.
@@ -30,7 +30,7 @@ To install the chart in a specific namespace use following commands:
 
 ```bash
 kubectl create ns vscode-server
-helm install vscode-server estenrye-helm-charts/vscode-server --namespace vscode-server --version 0.5.2
+helm install vscode-server estenrye-helm-charts/vscode-server --namespace vscode-server --version 0.5.3
 ```
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
@@ -89,7 +89,7 @@ helm install vscode-server estenrye-helm-charts/vscode-server --namespace vscode
 | tolerations | list | `[]` |  |
 | vscode_server.fullnameOverride | string | `""` |  |
 | vscode_server.image.pullPolicy | string | `"IfNotPresent"` | Configures the image pull policy for Visual Studio Code Server.  Valid options include [`Always`, `IfNotPresent`, `Never`] |
-| vscode_server.image.repository | string | `"linuxserver/code-server"` | Visual Studio Code Server Image Repository Name. |
+| vscode_server.image.repository | string | `"estenrye/vscode-server"` | Visual Studio Code Server Image Repository Name. |
 | vscode_server.image.tag | string | `""` | (string) Overrides the image tag for Visual Studio Code Server whose default is the chart appVersion. |
 | vscode_server.ingress.annotations | object | `{}` |  |
 | vscode_server.ingress.className | string | `""` |  |

--- a/charts/vscode-server/templates/clusterrolebinding.yaml
+++ b/charts/vscode-server/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vscode-server.fullname" . }}-binding
+  labels:
+    {{- include "vscode-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vscode-server.serviceAccountName" . }}
+  namespace: {{ Release.Namespace }}

--- a/charts/vscode-server/values.yaml
+++ b/charts/vscode-server/values.yaml
@@ -92,7 +92,7 @@ vscode_server:
 
   image:
     # -- Visual Studio Code Server Image Repository Name.
-    repository: linuxserver/code-server
+    repository: estenrye/vscode-server
 
     # -- Configures the image pull policy for Visual Studio Code Server.  Valid options include
     # [`Always`, `IfNotPresent`, `Never`]


### PR DESCRIPTION
This change adds support for admin access in the deployed namespace.
This change also adds a custom vscode-server image with build-essentials